### PR TITLE
ci: publish containers to GHCR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,3 +12,4 @@ jobs:
     permissions:
       contents: read
       packages: write
+    secrets: inherit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,44 +2,13 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [ main ]
   pull_request:
-    branches: ["**"]
+    branches: [ main ]
 
 jobs:
-  test:
-    name: Test
-    runs-on: ubuntu-latest
+  call-common-ci:
+    uses: its-the-vibe/.github/.github/workflows/common-ci.yaml@main
     permissions:
       contents: read
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Run tests
-        run: make test
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: latest
-
-      - name: Run lint
-        run: make lint
+      packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # Build stage
-FROM golang:1.26.6-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /build
 
@@ -13,22 +16,20 @@ RUN go mod download
 COPY *.go ./
 
 # Build the binary
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags="-w -s" -o innergate .
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o innergate .
 
-# Final stage - using scratch for minimal image
-FROM scratch
+# Final stage (distroless)
+FROM gcr.io/distroless/static-debian13:nonroot
 
-# Copy the binary from builder
 COPY --from=builder /build/innergate /innergate
-
-# Copy SSL certificates for HTTPS requests (if needed)
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # Expose default port
 EXPOSE 8080
 
 # Set default config path
 ENV CONFIG_PATH=/config.json
+
+USER nonroot:nonroot
 
 # Run the binary
 ENTRYPOINT ["/innergate"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    image: ghcr.io/its-the-vibe/innergate:latest
+    pull_policy: always
     read_only: true
     extra_hosts:
       - "host.docker.internal:host-gateway"    


### PR DESCRIPTION
## Summary
- Build cross-platform static binary using `--platform=$BUILDPLATFORM` with `TARGETOS`/`TARGETARCH` args
- Switch runtime from `scratch` to `gcr.io/distroless/static-debian13:nonroot` (removes CA cert copy and `apk add ca-certificates`)
- Add `USER nonroot:nonroot` instruction
- Update Compose to use GHCR image with `pull_policy: always`
- Delegate CI/CD to the shared organisation workflow